### PR TITLE
chore: add repository/homepage fields to extension package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "kubernetes-pack",
+  "repository": "https://github.com/podman-desktop/extension-pack-kubernetes",
+  "homepage": "https://github.com/podman-desktop/extension-pack-kubernetes#readme",
   "displayName": "Kubernetes Extension Pack",
   "description": "Recommended Kubernetes extensions for Podman Desktop",
   "version": "0.2.0-next",


### PR DESCRIPTION
### What does this PR do?

Add missing `repository` and `homepage` fields in the extension `package.json`.

### Screenshot / video of UI

N/A (metadata-only change)

### What issues does this PR fix or reference?

Closes #7

### How to test this PR?

1. Open `package.json`.
2. Verify both `repository` and `homepage` are present and point to this GitHub repository.
3. Confirm no other files changed.
